### PR TITLE
Respond to media element events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { init, uiReady } from "senza-sdk";
+import { init, uiReady, lifecycle } from "senza-sdk";
 import { SenzaShakaPlayer } from "./senzaShakaPlayer.js";
 
 const TEST_VIDEO = "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd";
@@ -10,9 +10,7 @@ window.addEventListener("load", async () => {
     await init();
     player = new SenzaShakaPlayer(video);
     await player.load(TEST_VIDEO);
-    if (!player.isInRemotePlayback) {
-      await player.play();
-    }
+    await video.play();
     uiReady();
   } catch (error) {
     console.error(error);
@@ -21,11 +19,31 @@ window.addEventListener("load", async () => {
 
 document.addEventListener("keydown", async function (event) {
   switch (event.key) {
-    case "Enter": await player.togglePlayback(); break;
-    case "Escape": await player.playPause(); break;
-    case "ArrowLeft": player.skip(-30); break;
-    case "ArrowRight": player.skip(30); break;
+    case "Enter": await togglePlayback(); break;
+    case "Escape": await playPause(); break;
+    case "ArrowLeft": skip(-30); break;
+    case "ArrowRight": skip(30); break;
     default: return;
   }
   event.preventDefault();
 });
+
+async function togglePlayback() {
+  if (lifecycle.state == lifecycle.UiState.BACKGROUND) {
+    await player.moveToLocalPlayback();
+  } else {
+    await player.moveToRemotePlayback();
+  }
+}
+
+async function playPause() {
+  if (video.paused) {
+    await video.play();
+  } else {
+    await video.pause();
+  }
+}
+
+function skip(seconds) {
+  video.currentTime = video.currentTime + seconds;
+}

--- a/senzaShakaPlayer.js
+++ b/senzaShakaPlayer.js
@@ -4,18 +4,7 @@ import shaka from "shaka-player";
  * SenzaShakaPlayer subclass of Shaka that handles both local and remote playback.
  *
  * @class SenzaShakaPlayer
- * @property {number} currentTime - Gets or sets the current playback time.
- * @property {boolean} paused - Indicates whether the player is paused.
- * @property {number} playbackRate - Gets or sets the playback rate. NOTE currently supported only on local player.
- * @fires SenzaShakaPlayer#ended - Indicates that the media has ended.
- * @fires SenzaShakaPlayer#error - Indicates that an error occurred.
- * @fires SenzaShakaPlayer#timeupdate - Indicates that the current playback time has changed.
- * @fires SenzaShakaPlayer#canplay - Indicates that the media is ready to play. NOTE currently supported only via local player.
- * @fires SenzaShakaPlayer#seeking - Indicates that the player is seeking. NOTE currently supported only via local player.
- * @fires SenzaShakaPlayer#seeked - Indicates that the player has finished seeking. NOTE currently supported only via local player.
- * @fires SenzaShakaPlayer#loadedmetadata - Indicates that the player has loaded metadata. NOTE currently supported only via local player.
- * @fires SenzaShakaPlayer#waiting - Indicates that the player is waiting for data. NOTE currently supported only via local player.
-  *
+ *
  * @example
  * import { SenzaShakaPlayer } from "./senzaShakaPlayer.js";
  *
@@ -23,21 +12,7 @@ import shaka from "shaka-player";
  *   const videoElement = document.getElementById("video");
  *   const player = new SenzaShakaPlayer(videoElement);
  *   await player.load("http://playable.url/file.mpd");
- *   await player.getMediaElement().play(); // Will start the playback on the local player
- *   document.addEventListener("keydown", async function (event) {
- *     switch (event.key) {
- *       case "ArrowLeft": {
- *         await player.moveToLocalPlayback(); // Will move the playback to the local player
- *         break;
- *       }
- *       case "ArrowRight": {
- *         player.moveToRemotePlayback(); // Will move the playback to the remote player
- *         break;
- *       }
- *       default: return;
- *     }
- *     event.preventDefault();
- *   });
+ *   await videoElement.play(); // will start the playback
  *
  * } catch (err) {
  *   console.error("SenzaShakaPlayer failed with error", err);
@@ -56,53 +31,7 @@ export class SenzaShakaPlayer extends shaka.Player {
 
     this.remotePlayer.attach(this.videoElement);
 
-    this.addOverrides(videoElement);
     this.addEventListeners();
-  }
-
- /**
-  * Replaces the implementation of methods on the video element including play and pause
-  * with a new function that calls the original as well as the equivalent methods on the
-  * remote player.
-  */
-  addOverrides(videoElement) {
-    // override play()
-    const localPlayerPlay = videoElement.play.bind(videoElement);
-    videoElement.play = async () => {
-      await localPlayerPlay();
-      await this.remotePlayer.play();
-    };
-
-    // override pause()
-    const localPlayerPause = videoElement.pause.bind(videoElement);
-    videoElement.pause = async () => {
-      if (this.isInRemotePlayback) {
-        console.warn("Pausing while in remote playback is not supported yet.");
-      } else {
-        await localPlayerPause();
-        await this.remotePlayer.pause();
-      }
-    };
-
-    // override currentTime
-    videoElement.getCurrentTime = () => videoElement.__proto__.__lookupGetter__('currentTime').call(videoElement);
-    videoElement.setCurrentTime = (value) => videoElement.__proto__.__lookupSetter__('currentTime').call(videoElement, value);
-    Object.defineProperty(videoElement, 'currentTime', {
-      get: () => {
-        return this.isInRemotePlayback ? this.remotePlayer.currentTime : videoElement.getCurrentTime();
-      },
-      set: (time) => {
-        if (this.isInRemotePlayback) {
-          console.warn("Setting currentTime while in remote playback is not supported yet.");
-        } else {
-          console.log('Set currentTime:', time);
-          videoElement.setCurrentTime(time);
-          this.remotePlayer.currentTime = time;
-        }
-      },
-      configurable: true,
-      enumerable: true,
-    });
   }
 
   addEventListeners() {
@@ -121,155 +50,38 @@ export class SenzaShakaPlayer extends shaka.Player {
       if (!this.isInRemotePlayback) {
         return;
       }
-      this.videoElement.setCurrentTime(this.remotePlayer.currentTime);
-      // not necessary to dispatch a new event, since setting the current time will do so anyway
-      // this.videoElement.dispatchEvent(new Event("timeupdate"));
+      this.videoElement.currentTime = this.remotePlayer.currentTime;
     });
 
     this.addEventListener("error", (event) => {
       console.log("localPlayer error:", event.detail.errorCode, event.detail.message);
     });
-    
-    this.videoElement.addEventListener("timeupdate", () => {
-      if (this.isInRemotePlayback) {
-        return;
-      }
-      // added this back as it seems to work better with it. Let's discuss why it was removed.
-      this.remotePlayer.currentTime = this.videoElement.getCurrentTime();
-      this.dispatchEvent(new Event("timeupdate"));
+
+    this.videoElement.addEventListener("play", () => {
+      this.remotePlayer.play();
+    });
+ 
+    this.videoElement.addEventListener("pause", () => {
+      this.remotePlayer.pause();
+    });
+
+    this.videoElement.addEventListener("seeked", () => {
+      console.log("Seeking remotePlayer.currentTime to", this.videoElement.currentTime);
+      this.remotePlayer.currentTime = this.videoElement.currentTime;
+    });
+ 
+    this.videoElement.addEventListener("ratechange", () => {
+      console.log("Setting remotePlayer.playbackRate to", this.videoElement.playbackRate);
+      this.remotePlayer.playbackRate = this.videoElement.playbackRate;
     });
   }
 
   /**
-   * Should we move this to lifecycle?
+   * Helper function that makes it easier to check if lifecycle.state is
+   * either background or inTransitionToBackground.
    */
   get isInRemotePlayback() {
     return lifecycle.state === lifecycle.UiState.BACKGROUND || lifecycle.state === lifecycle.UiState.IN_TRANSITION_TO_BACKGROUND;
-  }
-
-  /**
-   * DEPRECATED: use the property on the media element. Remote player only supports 1x.
-   */
-  get playbackRate() {
-    if (this.isInRemotePlayback) {
-      console.warn("playbackRate in remote playback is not supported yet.");
-      return this.remotePlayer.playbackRate === undefined ? 1 : this.remotePlayer.playbackRate;
-    } else {
-      return this.videoElement.playbackRate;
-    }
-  }
-
-  /**
-   * DEPRECATED: use the property on the media element. Remote player only supports 1x.
-   */
-  set playbackRate(rate) {
-    if (this.isInRemotePlayback) {
-      console.warn("playbackRate in remote playback is not supported yet.");
-    }
-    this.remotePlayer.playbackRate = this.videoElement.playbackRate = rate;
-  }
-
-  /**
-   * Indicates whether the player is paused.
-   * DEPRECATED: use the property on the media element, no need to override it.
-   *
-   * @readonly
-   * @type {boolean}
-   */
-  get paused() {
-    return this.isInRemotePlayback ? false : this.videoElement.paused;
-  }
-
-  /**
-   * Gets the current playback time.
-   * DEPRECATED: use the overridden property on the media element.
-   *
-   * @type {number}
-   */
-  get currentTime() {
-    this.videoElement.currentTime;
-  }
-
-  /**
-   * Sets the current playback time.
-   * NOTE: When in remote playback, this will not affect the remote player.
-   * DEPRECATED: use the overridden property on the media element.
-   * @param {number} time - The time to set the current playback to.
-   */
-  set currentTime(time) {
-    this.videoElement.currentTime = time;
-  }
-
-  /**
-   * Loads a media URL into both local and remote players.
-   *
-   * @param {string} url - The URL of the media to load.
-   * @returns {Promise<void>}
-   */
-  async load(url) {
-    if (!this.isInRemotePlayback || remotePlayer.getAssetUri() !== url) {
-      try {
-        await this.remotePlayer.load(url);
-      } catch (error) {
-        console.log("Couldn't load remote player. Error:", error);
-      }
-    }
-    try {
-      await super.load(url);
-    } catch (error) {
-      console.log("Couldn't load local player. Error:", error);
-    }
-  }
-
-  /**
-   * Toggles between local and remote playback
-   */
-  async togglePlayback() {
-    if (this.isInRemotePlayback) {
-      await this.moveToLocalPlayback();
-    } else {
-      this.moveToRemotePlayback();
-    }
-  }
-
-  /**
-   * Switches between play and pause.
-   */
-  async playPause() {
-    if (this.videoElement.paused) {
-      await this.videoElement.play();
-    } else {
-      await this.videoElement.pause();
-    }
-  }
-
-  /**
-   * Adjusts the current time of the player by a given number of seconds.
-   * Moves forward if the number is positive, or backwards if it is negative.
-   */
-  skip(seconds) {
-    this.videoElement.currentTime = this.videoElement.currentTime + seconds;
-  }
-
-  /**
-   * Plays the media.
-   * Will start the playback on the local player.
-   * To move the playback to the remote player, call {@link moveToRemotePlayback}.
-   * DEPRECATED: use the overridden method on the media element.
-   *
-   * @returns {Promise<void>}
-   */
-  async play() {
-    await this.videoElement.play();
-  }
-
-  /**
-   * Pauses the media on both local and remote players.
-   * NOTE: When in remote playback, this will not have any affect.
-   * DEPRECATED: use the overridden method on the media element.
-   */
-  async pause() {
-    await this.videoElement.pause();
   }
 
   /**
@@ -278,15 +90,39 @@ export class SenzaShakaPlayer extends shaka.Player {
    * @returns {Promise<void>}
    */
   async moveToLocalPlayback() {
-    await this.videoElement.play(); // why is this needed?
-    lifecycle.moveToForeground();
+    await lifecycle.moveToForeground();
   }
 
   /**
    * Moves playback to remote player.
+   * The timecode needs to be synced here if audiosync is not enabled. 
+   *
+   * @returns {Promise<void>}
    */
-  moveToRemotePlayback() {
-    lifecycle.moveToBackground();
+  async moveToRemotePlayback() {
+    this.remotePlayer.currentTime = this.videoElement.currentTime;
+    await lifecycle.moveToBackground();
+  }
+
+  /**
+   * Loads a media URL into both local and remote players.
+   *
+   * @param {string} url - The URL of the media to load.
+   * @returns {Promise<void>}
+   */
+  async load(url, startTime, mimeType) {
+    if (!this.isInRemotePlayback || remotePlayer.getAssetUri() !== url) {
+      try {
+        await this.remotePlayer.load(url);
+      } catch (error) {
+        console.log("Couldn't load remote player. Error:", error);
+      }
+    }
+    try {
+      await super.load(url, startTime, mimeType);
+    } catch (error) {
+      console.log("Couldn't load local player. Error:", error);
+    }
   }
 
   /**

--- a/senzaShakaPlayer.js
+++ b/senzaShakaPlayer.js
@@ -24,8 +24,8 @@ export class SenzaShakaPlayer extends shaka.Player {
    *
    * @param {HTMLVideoElement} videoElement - The video element to be used for local playback.
    */
-  constructor(videoElement) {
-    super(videoElement);
+  constructor(videoElement, videoContainer, dependencyInjector) {
+    super(videoElement, videoContainer, dependencyInjector);
     this.videoElement = videoElement;
     this.remotePlayer = remotePlayer;
 
@@ -66,13 +66,7 @@ export class SenzaShakaPlayer extends shaka.Player {
     });
 
     this.videoElement.addEventListener("seeked", () => {
-      console.log("Seeking remotePlayer.currentTime to", this.videoElement.currentTime);
       this.remotePlayer.currentTime = this.videoElement.currentTime;
-    });
- 
-    this.videoElement.addEventListener("ratechange", () => {
-      console.log("Setting remotePlayer.playbackRate to", this.videoElement.playbackRate);
-      this.remotePlayer.playbackRate = this.videoElement.playbackRate;
     });
   }
 


### PR DESCRIPTION
* Modified the JSDoc comment to remove properties and events that actually belong on the media element, not the SenzaShakaPlayer class. Also removed the keydown listener as it makes the docs too long.
* Updated constructor signature to match superclass.
* The constructor was getting long so I moved the event handlers to a separate function.
* When receiving a timeupdate from the local player, no longer dispatching an event on the player class because it is not necessary. If we are not syncing the remote player time here then we can remove this listener.
* Added listeners for media element play and pause events, in which we call the equivalent methods on the remote player.
* Added listener for media player seeked event, in which we set the currentTime on the remote player from the local player, respectively.
* Removed code for setting playbackRate on the remote player because this is not supported.
* Removed play and pause methods as these should be called on the media element. Using play and pause events to sync with remote player.
* Removed currentTime, playbackRate, and paused properties from the player, because these are properties of the media element. Replaced with seeked and ratechange events.
* Updated method signature of load function to match superclass.
* Moved togglePlayback, playPause and skip functions back to index.js as this is functionality that should be in the app, not the player.
* Restored call to sync the timecode in moveToRemotePlayback, as this is required if audio sync is not enabled. We need to consider if there is a better way to do this so that we can make the interface consistent.
