### PR TITLE
Remove lifecycle methods, add attach method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Senza Shaka Player
 
-The `SenzaShakaPlayer` is a subclass of the Shaka player that seamlessly handles playback of both local and remote video. It abstracts the complexities of switching between local playback using Shaka Player and remote playback using the Senza cloud connector.
+The Senza `ShakaPlayer` is a subclass of the Shaka player that seamlessly handles playback of both local and remote video. It abstracts the complexities of switching between local playback using Shaka Player and remote playback using the Senza cloud connector.
 
 ## Properties
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ window.addEventListener("load", async () => {
 
 document.addEventListener("keydown", async function (event) {
   switch (event.key) {
-    case "Enter": await togglePlayback(); break;
+    case "Enter": await toggleBackground(); break;
     case "Escape": await playPause(); break;
     case "ArrowLeft": skip(-30); break;
     case "ArrowRight": skip(30); break;
@@ -28,11 +28,14 @@ document.addEventListener("keydown", async function (event) {
   event.preventDefault();
 });
 
-async function togglePlayback() {
+async function toggleBackground() {
   if (lifecycle.state == lifecycle.UiState.BACKGROUND) {
-    await player.moveToLocalPlayback();
+    await lifecycle.moveToForeground();
   } else {
-    await player.moveToRemotePlayback();
+    // remove this line once the remotePlayer has been updated to sync 
+    // automatically regardless of whether seamless switch is enabled
+    player.remotePlayer.currentTime = video.currentTime;
+    await lifecycle.moveToBackground();
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import { init, uiReady, lifecycle } from "senza-sdk";
-import { SenzaShakaPlayer } from "./senzaShakaPlayer.js";
+import { ShakaPlayer } from "./shakaPlayer.js";
 
 const TEST_VIDEO = "https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd";
 
@@ -8,7 +8,7 @@ let player;
 window.addEventListener("load", async () => {
   try {
     await init();
-    player = new SenzaShakaPlayer(video);
+    player = new ShakaPlayer(video);
     await player.load(TEST_VIDEO);
     await video.play();
     uiReady();

--- a/senzaShakaPlayer.js
+++ b/senzaShakaPlayer.js
@@ -26,17 +26,25 @@ export class SenzaShakaPlayer extends shaka.Player {
    */
   constructor(videoElement, videoContainer, dependencyInjector) {
     super(videoElement, videoContainer, dependencyInjector);
-    this.videoElement = videoElement;
     this.remotePlayer = remotePlayer;
+    this.handlePlayerEvents();
 
-    this.remotePlayer.attach(this.videoElement);
-
-    this.addEventListeners();
+    if (videoElement) {
+      this.videoElement = videoElement;
+      this.remotePlayer.attach(this.videoElement);
+      this.handleMediaEvents();
+    }
   }
 
-  addEventListeners() {
+  async attach(videoElement, initializeMediaSource) {
+    super.attach(videoElement, initializeMediaSource);
+    this.videoElement = videoElement;
+    this.remotePlayer.attach(this.videoElement);
+    this.handleMediaEvents();
+  }
+
+  handlePlayerEvents() {
     this.remotePlayer.addEventListener("ended", () => {
-      console.log("remotePlayer ended");
       lifecycle.moveToForeground();
       this.videoElement.dispatchEvent(new Event("ended"));
     });
@@ -56,7 +64,9 @@ export class SenzaShakaPlayer extends shaka.Player {
     this.addEventListener("error", (event) => {
       console.log("localPlayer error:", event.detail.errorCode, event.detail.message);
     });
+  }
 
+  handleMediaEvents() {
     this.videoElement.addEventListener("play", () => {
       this.remotePlayer.play();
     });

--- a/senzaShakaPlayer.js
+++ b/senzaShakaPlayer.js
@@ -79,26 +79,6 @@ export class SenzaShakaPlayer extends shaka.Player {
   }
 
   /**
-   * Moves playback to local player.
-   *
-   * @returns {Promise<void>}
-   */
-  async moveToLocalPlayback() {
-    await lifecycle.moveToForeground();
-  }
-
-  /**
-   * Moves playback to remote player.
-   * The timecode needs to be synced here if audiosync is not enabled. 
-   *
-   * @returns {Promise<void>}
-   */
-  async moveToRemotePlayback() {
-    this.remotePlayer.currentTime = this.videoElement.currentTime;
-    await lifecycle.moveToBackground();
-  }
-
-  /**
    * Loads a media URL into both local and remote players.
    *
    * @param {string} url - The URL of the media to load.

--- a/shakaPlayer.js
+++ b/shakaPlayer.js
@@ -1,26 +1,26 @@
 import { remotePlayer, lifecycle } from "senza-sdk";
 import shaka from "shaka-player";
 /**
- * SenzaShakaPlayer subclass of Shaka that handles both local and remote playback.
+ * ShakaPlayer subclass of Shaka that handles both local and remote playback.
  *
- * @class SenzaShakaPlayer
+ * @class ShakaPlayer
  *
  * @example
- * import { SenzaShakaPlayer } from "./senzaShakaPlayer.js";
+ * import { ShakaPlayer } from "./shakaPlayer.js";
  *
  * try {
  *   const videoElement = document.getElementById("video");
- *   const player = new SenzaShakaPlayer(videoElement);
+ *   const player = new ShakaPlayer(videoElement);
  *   await player.load("http://playable.url/file.mpd");
  *   await videoElement.play(); // will start the playback
  *
  * } catch (err) {
- *   console.error("SenzaShakaPlayer failed with error", err);
+ *   console.error("ShakaPlayer failed with error", err);
  * }
  */
-export class SenzaShakaPlayer extends shaka.Player {
+export class ShakaPlayer extends shaka.Player {
   /**
-   * Creates an instance of SenzaShakaPlayer, which is a subclass of shaka.Player.
+   * Creates an instance of ShakaPlayer, which is a subclass of shaka.Player.
    *
    * @param {HTMLVideoElement} videoElement - The video element to be used for local playback.
    */
@@ -117,7 +117,7 @@ export class SenzaShakaPlayer extends shaka.Player {
    * @param {(response: { data : ArrayBuffer | ArrayBufferView , headers : { [ key: string ]: string } , originalUri : string , status ? : number , timeMs ? : number , uri : string }) => void | null} responseFilter - Optional response filter function.
    *
    * @example
-   * senzaShakaPlayer.configureDrm("https://proxy.uat.widevine.com/proxy", (request) => {
+   * shakaPlayer.configureDrm("https://proxy.uat.widevine.com/proxy", (request) => {
    *  console.log("Requesting license from Widevine server");
    *  request.headers["Authorization"] = "Bearer <...>";
    * });

--- a/shakaPlayer.js
+++ b/shakaPlayer.js
@@ -27,23 +27,24 @@ export class ShakaPlayer extends shaka.Player {
   constructor(videoElement, videoContainer, dependencyInjector) {
     super(videoElement, videoContainer, dependencyInjector);
     this.remotePlayer = remotePlayer;
-    this.handlePlayerEvents();
+    this.addPlayerEventListeners();
 
     if (videoElement) {
       this.videoElement = videoElement;
       this.remotePlayer.attach(this.videoElement);
-      this.handleMediaEvents();
+      this.addMediaEventListeners();
     }
   }
 
   async attach(videoElement, initializeMediaSource) {
     super.attach(videoElement, initializeMediaSource);
+    if (this.videoElement !== undefined) removeMediaEventListeners();
     this.videoElement = videoElement;
     this.remotePlayer.attach(this.videoElement);
-    this.handleMediaEvents();
+    this.addMediaEventListeners();
   }
 
-  handlePlayerEvents() {
+  addPlayerEventListeners() {
     this.remotePlayer.addEventListener("ended", () => {
       lifecycle.moveToForeground();
       this.videoElement.dispatchEvent(new Event("ended"));
@@ -66,18 +67,20 @@ export class ShakaPlayer extends shaka.Player {
     });
   }
 
-  handleMediaEvents() {
-    this.videoElement.addEventListener("play", () => {
-      this.remotePlayer.play();
-    });
- 
-    this.videoElement.addEventListener("pause", () => {
-      this.remotePlayer.pause();
-    });
-
-    this.videoElement.addEventListener("seeked", () => {
-      this.remotePlayer.currentTime = this.videoElement.currentTime;
-    });
+  addMediaEventListeners() {
+    this.videoElement.addEventListener("play", this.remotePlayer.play);
+    this.videoElement.addEventListener("pause", this.remotePlayer.pause);
+    this.videoElement.addEventListener("seeked", this.updateCurrentTime);
+  }
+  
+  removeMediaEventListeners() {
+    this.videoElement.removeEventListener("play", this.remotePlayer.play);
+    this.videoElement.removeEventListener("pause", this.remotePlayer.pause);
+    this.videoElement.removeEventListener("seeked", this.updateCurrentTime);
+  }
+  
+  updateCurrentTime() {
+    this.remotePlayer.currentTime = this.videoElement.currentTime;
   }
 
   /**


### PR DESCRIPTION
Removed the lifecycle methods from the player class. In the app, now calling lifecycle methods directly.

For now, we are continuing to sync the current time before switching to background. When we update the remote player to do this automatically then we can remove that line.

----

Shaka supports passing the media element in the constructor or the attach() method. This commit overrides attach() to do the same things as in the constructor.

Split addEventListeners() into two methods, addPlayerEventListeners() and addMediaEventListeners(), to support the possibility that the latter could be called multiple times. If replacing a media element, calls removeMediaEventListeners() so we do not listen to multiple elements.

----

Renamed class from SenzaShakaPlayer to ShakaPlayer. 

Merged in PR #8 with updated major version of Shaka.
